### PR TITLE
add support for the esp8266's single serial port

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library for the Flysky/Turnigy RC iBUS protocol - servo (receiv
 paragraph=With this library you can interface to any RC receiver that supports the Flysky iBUS protocol (such as TGY-IA6B). Flysky iBUS uses a half-duplex asynchronous protocol format at 115200 baud. The library requires at least one free hardware UART (serial) port. The library can be used to receive data (typically servo data) and send data (telemetry or sensors).
 category=Communication
 url=https://github.com/bmellink/IBusBM
-architectures=avr,esp32,stm32,mbed,STM32F1,megaavr
+architectures=avr,esp32,stm32,mbed,STM32F1,megaavr,esp8266
 includes=IBusBM.h


### PR DESCRIPTION
### Description of Changes

**Feature Added**: ESP8266 Hardware Serial Port Compatibility

This update modifies the library to support the ESP8266's single hardware UART port.

### Test Environment

**Transmitter**: FlySky FS-i6 (original firmware)  
**Receiver**: FS-iA6B

**Connections**:
- GND to GND
- 5V to 5V
- iBus (Sens) to Rx (ESP8266) 
- Rx (ESP8266) to TX (ESP8266) with a diode

### Test Code

```cpp
#include <IBusBM.h>

IBusBM IBus; 

void setup() {
  IBus.begin(Serial);
  IBus.addSensor(IBUSS_RPM);
  IBus.addSensor(IBUSS_TEMP);
}

#define TEMPBASE 400    // base value for 0'C

// sensor values
uint16_t speed = 0;
uint16_t temp = TEMPBASE + 200; // start at 20'C

void loop() {
  IBus.setSensorMeasurement(1, speed);
  speed += 10;                // increase motor speed by 10 RPM
  IBus.setSensorMeasurement(2, temp++); // increase temperature by 0.1 'C every loop
  delay(500);
}
