### PR TITLE
Confimed support for FS-iA10B

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The iBUS protocol is a half-duplex protocol developed by Flysky to control multi
 
 The protocol can also connect sensors to send back telemetry information to a RC transceiver. Depending on your transmitter you can use multiple sensors. You can define up to 10 sensors using this library. The Turnigy FS-MT6 only supports voltage, temperature, motor speed and pressure, but OpenTX based receivers support a long list of sensors, which can all be used by passing the right sensor ID to the addSensor() function.
 
-This library was written and tested for the TGY-IA6B receiver and should work for other receivers too (such as the FS-iA10 and TGY-iA10).
+This library was written and tested for the TGY-IA6B receiver and is confirmed to work with the FS-iA10B receiver using FlySky i6X 10ch controller. This librairy should work for other receivers too (TGY-iA10).
 The TGY-IA6B has 2 iBUS pins: one for the servos (only output) and one for the sensors/telemetry
 (which uses a half-duplex protocol to switch between output and input to poll for sensor data).
 


### PR DESCRIPTION
I have used and been able to confirm that this lib works just fine with the FlySky i10B (10 channel receiver) on an Arduino Mega. I have one at home, and controlled motors and servos with it using this library. I have encountered no issues, and can confidently say that this library is compatible.

[FlySky i10B used to test](https://www.amazon.ca/HAWKS-WORK-Transmitter-i6X-iA10B/dp/B0BSBVSVQC/ref=sr_1_1_sspa?crid=3NJ6FR37UMS33&dib=eyJ2IjoiMSJ9.RE0-WjvtVpeM48YKpHwJyoJ_DB5lFDAuPuCYm9DgSnrid7zUALpkUPUYu--tJ30PckSY5I_iGwhlkKmcBatymi6OHemny4cnkLi6MR41g8BeM4ml9hn4Py5GIfFrvty2wZOFHNRf-QbUHs5cIJRmRXOpmDeGwxTOooP7kyZUZGnq866tR_a_prhXrcyskk4kS8lkDMtvm5UFT5y6i9RiWoys4QUh-b2v6kJpwB9cqCEKHW6YYuSYpG5QW9P3LXEQA6advClz-eKth05UFUJdf1zA-ZNNOpCAmoCjqaqdy64.65HPUWjF5wBxTaTVraNa4DDNZsxzFRUux4Q4yrdcmJI&dib_tag=se&keywords=flysky%2B10ch&qid=1733197176&sprefix=flysky%2B10ch%2Caps%2C213&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1)